### PR TITLE
Remove direct comparison against undefined.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,5 +8,5 @@
  * @returns {Boolean} `true`, if the input is `undefined`, `false` otherwise.
  */
 module.exports = function isUndefined(input) {
-    return input === undefined;
+    return typeof input === 'undefined';
 };


### PR DESCRIPTION
Undefined can be overwritten - using type comparison instead.
